### PR TITLE
Upgraded EnclaveAPI to 1.5.8 and Pointed to Staging

### DIFF
--- a/example/covid-validation/app.py
+++ b/example/covid-validation/app.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from sklearn.metrics import accuracy_score, recall_score,confusion_matrix
 from cmath import sqrt
 from typing import List, Dict, ByteString
+import base64
 import EnclaveSDK
 from EnclaveSDK import File, Report, LogData
 
@@ -16,7 +17,7 @@ configuration = EnclaveSDK.Configuration("https://localhost:5000")
 sas_url = None 
 
 # Uncomment the following lines to use the EnclaveAPI Sandbox, make sure to comment before uploading to EscrowAI
-# configuration.host = "https://sandbox.dev.escrow.beekeeperai.com"
+# configuration.host = "https://enclaveapi.stg.escrow.beekeeperai.com"
 # sas_url = 'SAS-URL-WITH-READ-AND-LIST-PERMISSIONS' 
 
 api_client = EnclaveSDK.ApiClient(configuration)
@@ -32,7 +33,6 @@ def get_file_list(sas_url=None) -> List[File]:
 def download_file(file_name: str, sas_url=None) -> ByteString:
     api_instance = EnclaveSDK.DataApi(api_client)
     content = api_instance.api_v1_data_file_get(file_name, sas_url=sas_url)
-    api_instance.api_v1_data_files_get()
 
     return content
 

--- a/example/covid-validation/app.py
+++ b/example/covid-validation/app.py
@@ -1,4 +1,5 @@
 import io
+import os
 import json
 import pandas as pd
 from fastai.learner import load_learner
@@ -13,7 +14,7 @@ import EnclaveSDK
 from EnclaveSDK import File, Report, LogData
 
 # Set the code to access the Enclave API inside the enclave as follows:
-configuration = EnclaveSDK.Configuration("https://localhost:5000")
+configuration = EnclaveSDK.Configuration(os.getenv("ENCLAVE_URL", "http://localhost:5000"))
 sas_url = None 
 
 # Uncomment the following lines to use the EnclaveAPI Sandbox, make sure to comment before uploading to EscrowAI

--- a/example/covid-validation/requirements.txt
+++ b/example/covid-validation/requirements.txt
@@ -1,2 +1,2 @@
 fastai
-EnclaveSDK==1.5.4
+EnclaveSDK==1.5.8


### PR DESCRIPTION
This change modifies the COVID Example to use the latest 1.5.8 version of the EnclaveAPI (and associated SDK). This change also resolves a bug in the `download_file` method and directs users to use the staging instance of the EnclaveAPI sandbox.