### PR TITLE
pointing at HTTPS

### DIFF
--- a/example/covid-validation/app.py
+++ b/example/covid-validation/app.py
@@ -14,7 +14,7 @@ import EnclaveSDK
 from EnclaveSDK import File, Report, LogData
 
 # Set the code to access the Enclave API inside the enclave as follows:
-configuration = EnclaveSDK.Configuration(os.getenv("ENCLAVE_URL", "http://localhost:5000"))
+configuration = EnclaveSDK.Configuration(os.getenv("ENCLAVE_URL", "https://localhost:5000"))
 sas_url = None 
 
 # Uncomment the following lines to use the EnclaveAPI Sandbox, make sure to comment before uploading to EscrowAI


### PR DESCRIPTION
This resolves a small problem where the sandbox code is pointing at an `http` default endpoint for the EnclaveAPI. This is fixed.