### PR TITLE
Simplifying ESCROW_RUNTIME_LOCATION

### DIFF
--- a/example/covid-validation/app.py
+++ b/example/covid-validation/app.py
@@ -15,9 +15,7 @@ import EnclaveSDK
 from EnclaveSDK import File, Report, LogData
 
 # Use the ESCROW_RUNTIME_LOCATION environment variable to create an SDK configuration for the Sandbox
-ESCROW_RUNTIME_LOCATION = os.getenv("ESCROW_RUNTIME_LOCATION", "https://enclaveapi.escrow.beekeeperai.com/")
-parsed_enclave_url = urlparse(ESCROW_RUNTIME_LOCATION)
-enclave_url = f"{parsed_enclave_url.scheme}://{parsed_enclave_url.netloc}"
+enclave_url = os.getenv("ESCROW_RUNTIME_LOCATION", "https://enclaveapi.escrow.beekeeperai.com")
 
 configuration = EnclaveSDK.Configuration(enclave_url)
 # Use the SAS_URL environment variables to use the Data API in the Sandbox, otherwise default to None

--- a/example/diabetes-validation-r/app.R
+++ b/example/diabetes-validation-r/app.R
@@ -16,7 +16,6 @@ httr::set_config(httr::config(ssl_verifypeer = FALSE, ssl_verifyhost = FALSE))
 
 # Create the SDK configuration
 enclave_url <- Sys.getenv("ESCROW_RUNTIME_LOCATION", unset = "https://enclaveapi.escrow.beekeeperai.com")
-enclave_url <- sub("/api/v1$", "", enclave_url)
 
 # When testing in sandbox, add a SAS URL with at minimum read and list permissions
 SAS_URL <- base64_encode(Sys.getenv("SAS_URL"))


### PR DESCRIPTION
This change is a reflection of a simpler expected location for the EnclaveAPI in production. The need to trim a full path from the existing environment variable has been removed.