### PR TITLE
Swapping to ENCLAVE_URL for Env Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sample-validation-template/
 
 ## Early Access: Using the EnclaveAPI Sandbox
 
-When pointing the EnclaveSDK to the Enclave Sandbox (sandbox.dev.escrow.beekeeperai.com), you can perform the set of example API calls provided in this repository locally before deploying in EscrowAI. The code has the configuration required to point at the Enclave Sandbox and you need to uncomment those configurations to point at the sandbox. This system is under active development and is presented as-is.
+When pointing the EnclaveSDK to the Enclave Sandbox (enclaveapi.escrow.beekeeperai.com), you can perform the set of example API calls provided in this repository locally before deploying in EscrowAI. The code has the configuration required to point at the Enclave Sandbox and you need to uncomment those configurations to point at the sandbox. This system is under active development and is presented as-is.
 
 ## Preparing to Encrypt Your Secrets
 

--- a/example/covid-validation/app.py
+++ b/example/covid-validation/app.py
@@ -15,9 +15,7 @@ import EnclaveSDK
 from EnclaveSDK import File, Report, LogData
 
 # Use the ESCROW_RUNTIME_LOCATION environment variable to create an SDK configuration for the Sandbox
-ESCROW_RUNTIME_LOCATION = os.getenv("ESCROW_RUNTIME_LOCATION", "https://enclaveapi.escrow.beekeeperai.com/")
-parsed_enclave_url = urlparse(ESCROW_RUNTIME_LOCATION)
-enclave_url = f"{parsed_enclave_url.scheme}://{parsed_enclave_url.netloc}"
+enclave_url = os.getenv("ESCROW_RUNTIME_LOCATION", "https://enclaveapi.escrow.beekeeperai.com")
 
 configuration = EnclaveSDK.Configuration(enclave_url)
 # Use the SAS_URL environment variables to use the Data API in the Sandbox, otherwise default to None

--- a/example/covid-validation/app.py
+++ b/example/covid-validation/app.py
@@ -14,8 +14,8 @@ import base64
 import EnclaveSDK
 from EnclaveSDK import File, Report, LogData
 
-# Use the ESCROW_RUNTIME_LOCATION environment variable to create an SDK configuration for the Sandbox
-enclave_url = os.getenv("ESCROW_RUNTIME_LOCATION", "https://enclaveapi.escrow.beekeeperai.com")
+# Use the ENCLAVE_URL environment variable to create an SDK configuration for the Sandbox
+enclave_url = os.getenv("ENCLAVE_URL", "https://enclaveapi.escrow.beekeeperai.com")
 
 configuration = EnclaveSDK.Configuration(enclave_url)
 # Use the SAS_URL environment variables to use the Data API in the Sandbox, otherwise default to None

--- a/example/diabetes-validation-r/app.R
+++ b/example/diabetes-validation-r/app.R
@@ -16,7 +16,6 @@ httr::set_config(httr::config(ssl_verifypeer = FALSE, ssl_verifyhost = FALSE))
 
 # Create the SDK configuration
 enclave_url <- Sys.getenv("ESCROW_RUNTIME_LOCATION", unset = "https://enclaveapi.escrow.beekeeperai.com")
-enclave_url <- sub("/api/v1$", "", enclave_url)
 
 # When testing in sandbox, add a SAS URL with at minimum read and list permissions
 SAS_URL <- base64_encode(Sys.getenv("SAS_URL"))

--- a/example/diabetes-validation-r/app.R
+++ b/example/diabetes-validation-r/app.R
@@ -15,7 +15,7 @@ library(openssl)
 httr::set_config(httr::config(ssl_verifypeer = FALSE, ssl_verifyhost = FALSE))
 
 # Create the SDK configuration
-enclave_url <- Sys.getenv("ESCROW_RUNTIME_LOCATION", unset = "https://enclaveapi.escrow.beekeeperai.com")
+enclave_url <- Sys.getenv("ENCLAVE_URL", unset = "https://enclaveapi.escrow.beekeeperai.com")
 
 # When testing in sandbox, add a SAS URL with at minimum read and list permissions
 SAS_URL <- base64_encode(Sys.getenv("SAS_URL"))


### PR DESCRIPTION
This will resolve a small discrepancy in the env variable that is used for the sandbox and inside the enclave to designate the location of the sandbox. 